### PR TITLE
Make PDF manual compilation optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,14 @@ Create a build directory, then, from it, run cmake and make::
 
 Linux users can install Dwarf Therapist by running ``make install``. The destination directory can be changed by passing the ``-DCMAKE_INSTALL_PREFIX=/path/to/dwarftherapist`` option to cmake (e.g. ``cmake -DCMAKE_INSTALL_PREFIX=~/.local ..`` for a user-local installation).
 
+CMake options
+-------------
+
+Add ``-D<option name>=ON|OFF`` to cmake command line to enable or disable an optional feature.
+
+BUILD_MANUAL (default: OFF)
+  Enables building the PDF manual using Latex.
+ 
 Linux
 =====
 There is currently no official package for Linux.

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
 project(DwarfTherapistManual)
 
+option(BUILD_MANUAL "Compile the PDF manual" OFF)
 find_package(LATEX COMPONENTS PDFLATEX)
-if(LATEX_FOUND AND LATEX_PDFLATEX_FOUND)
+if(BUILD_MANUAL AND LATEX_FOUND AND LATEX_PDFLATEX_FOUND)
     include(UseLATEX)
     add_latex_document("Dwarf Therapist.tex"
         IMAGE_DIRS images


### PR DESCRIPTION
Building the manual requires opt-in using the BUILD_MANUAL cmake option.