### PR TITLE
Skill name changes

### DIFF
--- a/src/activityevent.cpp
+++ b/src/activityevent.cpp
@@ -88,7 +88,7 @@ void ActivityEvent::read_data(){
                         event_type = SQ_WATCH_DEMO;
                     }
                     //squad skill demo leaders and watchers
-                    QString skill_name = gdr->get_skill_name(m_df->read_int(m_address + mem->activity_offset("sq_skill")));
+                    QString skill_name = gdr->get_skill_name(m_df->read_int(m_address + mem->activity_offset("sq_skill")), false);
                     QString job_name = gdr->get_job((int)DwarfJob::ACTIVITY_OFFSET + (int)event_type)->name(skill_name);
                     add_action(histfig_id,event_type, job_name);
                     continue;

--- a/src/dfinstance.cpp
+++ b/src/dfinstance.cpp
@@ -538,8 +538,8 @@ void DFInstance::load_role_ratings(){
             attribute_raw_values.append(d->get_attribute(id).get_value());
         }
 
-        foreach(int id, gdr->get_skills().keys()){
-            skill_values.append(d->get_skill(id).get_balanced_level());
+        for (const auto &skill: gdr->get_skills()){
+            skill_values.append(d->get_skill(skill.id).get_balanced_level());
         }
 
         foreach(short val, d->get_traits()->values()){

--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -1716,8 +1716,6 @@ void Dwarf::read_skills() {
             foreach(Skill s, skills_by_level.values(skills_by_level.keys().last())){
                 m_moodable_skills.insert(s.id(),s);
             }
-        }else{
-            m_moodable_skills.insert(-1,Skill());
         }
     }else{
         int mood_skill = m_df->read_short(m_address +m_mem->dwarf_offset("mood_skill"));
@@ -2596,14 +2594,16 @@ QString Dwarf::tooltip_text() {
 
     if(!m_is_animal && s->value("tooltip_show_mood",false).toBool()){
         QStringList skill_names;
-        foreach(int skill_id, m_moodable_skills.keys()){
-            skill_names << gdr->get_skill_name(skill_id, true, true);
+        if (!m_moodable_skills.isEmpty()) {
+            foreach(int skill_id, m_moodable_skills.keys()){
+                skill_names << gdr->get_skill_name(skill_id, true);
+            }
+            skill_names.removeDuplicates();
         }
-        skill_names.removeDuplicates();
-        if(skill_names.count() > 0){
-            tt.append(tr("<b>Highest Moodable Skill:</b> %1")
-                      .arg(skill_names.join(",")));
+        else {
+            skill_names << tr("Craftsdwarf (Bone/Stone/Wood)");
         }
+        tt.append(tr("<b>Highest Moodable Skill:</b> %1").arg(skill_names.join(",")));
     }
 
     if(!personality_summary.isEmpty())

--- a/src/dwarfmodel.cpp
+++ b/src/dwarfmodel.cpp
@@ -369,19 +369,14 @@ void DwarfModel::build_rows() {
                 }
             }else if(m_group_by == GB_HIGHEST_MOODABLE){
                 QList<Skill> skills = d->get_moodable_skills().values();
-                if(skills.count() > 1){
+                if (skills.count() > 1)
                     m_grouped_dwarves["~Random~"].append(d);
-                }else{
-                    if(d->had_mood()){
-                        m_grouped_dwarves["~Had Mood~"].append(d);
-                    }else{
-                        if(skills.at(0).capped_level() == -1){
-                            m_grouped_dwarves["~Craft (Bone/Stone/Wood)~"].append(d);
-                        }else{
-                            m_grouped_dwarves[skills[0].name()].append(d);
-                        }
-                    }
-                }
+                else if(d->had_mood())
+                    m_grouped_dwarves["~Had Mood~"].append(d);
+                else if(skills.isEmpty())
+                    m_grouped_dwarves["~Craft (Bone/Stone/Wood)~"].append(d);
+                else
+                    m_grouped_dwarves[skills[0].name()].append(d);
             }else if(m_group_by == GB_HIGHEST_SKILL){
                 Skill highest = d->highest_skill();
                 QString level = gdr->get_skill_level_name(highest.capped_level());
@@ -448,7 +443,7 @@ void DwarfModel::build_row(const QString &key) {
         } else if (m_group_by == GB_HIGHEST_MOODABLE) {
             //show generic mood, random and had mood at the top/bottom
             QList<Skill> skills = first_dwarf->get_moodable_skills().values();
-            if(first_dwarf->had_mood() || skills.at(0).capped_level() < 0 || skills.count() > 1){
+            if(first_dwarf->had_mood() || skills.isEmpty() || skills.count() > 1){
                 agg_first_col->setData(QChar(128), DR_SORT_VALUE);
             }else{
                 agg_first_col->setData(skills[0].name(), DR_SORT_VALUE);

--- a/src/gridviewdialog.cpp
+++ b/src/gridviewdialog.cpp
@@ -477,13 +477,12 @@ void GridViewDialog::draw_column_context_menu(const QPoint &p) {
 
     //SKILL
     QMenu *m_skill = m_cmh->create_title_menu(m,tr("Skill"), tr("Skill columns function as a read-only display of a dwarf's skill in a particular area."));
-    m_cmh->add_sub_menus(m_skill,gdr->get_ordered_skills().count() / 15);
-    QPair<int, QPair<QString,QString> > skill_pair;
-    foreach(skill_pair, gdr->get_ordered_skills()) {
-        QMenu *menu_to_use = m_cmh->find_menu(m_skill,skill_pair.second.first);
-        QAction *a = menu_to_use->addAction(skill_pair.second.first, this, SLOT(add_skill_column()));
-        a->setData(skill_pair.first);
-        a->setToolTip(tr("Add a column for skill %1 (ID%2)").arg(skill_pair.second.first).arg(skill_pair.first));
+    m_cmh->add_sub_menus(m_skill,gdr->get_total_skill_count() / 15);
+    for (auto skill: gdr->get_ordered_skills()) {
+        QMenu *menu_to_use = m_cmh->find_menu(m_skill,skill->noun);
+        QAction *a = menu_to_use->addAction(skill->noun, this, SLOT(add_skill_column()));
+        a->setData(skill->id);
+        a->setToolTip(tr("Add a column for skill %1 (ID%2)").arg(skill->noun).arg(skill->id));
     }
 
     //SPACER

--- a/src/highestmoodcolumn.cpp
+++ b/src/highestmoodcolumn.cpp
@@ -56,20 +56,22 @@ QStandardItem *HighestMoodColumn::build_cell(Dwarf *d) {
     QString pixmap_name(":img/question-frame.png");
 
     QHash<int,Skill> skills = d->get_moodable_skills();
-    if(skills.count() > 1){
+    if (skills.count() > 1) {
         m_sort_val = 1000 + skills.count();
         m_skill_id = -1;
-    }else if(skills.count() <= 1){
+    }
+    else if (skills.isEmpty()) {
+        m_sort_val = 0;
+        m_skill_id = -1;
+        pixmap_name = ":/profession/prof_24.png";
+    }
+    else {
         Skill s = skills.values().at(0);
         m_skill_id = s.id();
-        int img_id = 24;
-        if(s.capped_level() != -1){
-            img_id = gdr->get_mood_skill_prof(s.id()) + 1; //prof images start at 1, id start at 0
-        }
+        int img_id = gdr->get_mood_skill_prof(s.id()) + 1; //prof images start at 1, id start at 0
         pixmap_name = ":/profession/prof_" + QString::number(img_id) + ".png";
 
-        int id = s.id() < 0 ? 0 : s.id();
-        m_sort_val = 50 + (id * 100);
+        m_sort_val = 50 + (s.id() * 100);
         if(d->had_mood())
             m_sort_val = 0 - m_sort_val;
 

--- a/src/roledialog.cpp
+++ b/src/roledialog.cpp
@@ -434,14 +434,13 @@ void roleDialog::draw_skill_context_menu(const QPoint &p) {
     GameDataReader *gdr = GameDataReader::ptr();
     ContextMenuHelper cmh;
 
-    cmh.add_sub_menus(m,gdr->get_ordered_skills().count()/15,false);
-    QPair<int, QPair<QString,QString> > skill_pair;
-    foreach(skill_pair, gdr->get_ordered_skills()) {
-        if(!m_role->skills.count((QString)skill_pair.first)){
-            QMenu *menu_to_use = cmh.find_menu(m,skill_pair.second.first);
-            a = menu_to_use->addAction(skill_pair.second.first, this, SLOT(add_skill()));
-            a->setData(skill_pair.first);
-            a->setToolTip(tr("Include %1 (ID %2) as an aspect for this role.)").arg(skill_pair.second.first).arg(skill_pair.first));
+    cmh.add_sub_menus(m,gdr->get_total_skill_count()/15,false);
+    for (auto skill: gdr->get_ordered_skills()) {
+        if(!m_role->skills.count((QString)skill->id)){
+            QMenu *menu_to_use = cmh.find_menu(m,skill->noun);
+            a = menu_to_use->addAction(skill->noun, this, SLOT(add_skill()));
+            a->setData(skill->id);
+            a->setToolTip(tr("Include %1 (ID %2) as an aspect for this role.)").arg(skill->noun).arg(skill->id));
         }
     }
 

--- a/src/scriptdialog.cpp
+++ b/src/scriptdialog.cpp
@@ -57,9 +57,8 @@ ScriptDialog::ScriptDialog(QWidget *parent)
     //SKILLS
     QString skill_list = "<b>Skills Reference</b><table border=1 cellpadding=3 cellspacing=0 width=100%>"
         "<tr><th width=24%>Skill ID</th><th>Skill</th></tr>";
-    QPair<int, QPair<QString,QString> > skill_pair;
-    foreach(skill_pair, gdr->get_ordered_skills()) {
-        skill_list.append(QString("<tr><td><font color=blue>%1</font></td><td><b>%2</b></td></tr>").arg(skill_pair.first).arg(skill_pair.second.first));
+    for (auto skill: gdr->get_ordered_skills(false)) {
+        skill_list.append(QString("<tr><td><font color=blue>%1</font></td><td><b>%2</b></td></tr>").arg(skill->id).arg(skill->name));
     }
     skill_list.append("</table>");
     ui->text_skills->append(skill_list);

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -64,7 +64,8 @@ Skill::Skill(short id, uint exp, short rating, int rust, int skill_rate)
     , m_balanced_level(-1)
     , m_rust_level(0)
 {
-    m_name = GameDataReader::ptr()->get_skill_name(m_id,false,true);
+    if (m_id != -1)
+        m_name = GameDataReader::ptr()->get_skill_name(m_id);
     //defaults
     m_rust_rating = "";
     m_capped_level = m_raw_level > 20 ? 20 : m_raw_level;

--- a/src/skill.h
+++ b/src/skill.h
@@ -53,7 +53,7 @@ public:
     int skill_rate() const {return m_skill_rate;}
 
     QString to_string(bool include_level = true, bool include_exp_summary = true, bool use_color = true) const;
-    QString name() {return m_name;}
+    const QString &name() const {return m_name;}
     bool operator<(const Skill *s2) const;
 
     struct less_than_key

--- a/src/skillcolumn.cpp
+++ b/src/skillcolumn.cpp
@@ -250,22 +250,18 @@ QString SkillColumn::build_skill_desc(Dwarf *d, int skill_id){
     QString skill_str = "";
     short rating = d->get_skill_level(skill_id);
     float raw_rating = d->get_skill_level(skill_id, true, true);
-    if((skill_id != -1 && rating > -1) || d->had_mood()) {
-        if(skill_id == -1){
-            skill_str = tr("%1").arg(gdr->get_skill_name(skill_id,true));
-        }else{
-            skill_str = tr("<h4 style=\"margin:0;\">%1 %2</h4><br/><b>[Raw Level:</b> %3]<br/><b>Experience: </b>%4")
-                    .arg(gdr->get_skill_level_name(rating))
-                    .arg(gdr->get_skill_name(skill_id,true))
-                    .arg(QString::number((int)raw_rating))
-                    .arg(d->get_skill(skill_id).exp_summary());
+    if (skill_id != -1 && rating > -1) {
+        skill_str = tr("<h4 style=\"margin:0;\">%1 %2</h4><br/><b>[Raw Level:</b> %3]<br/><b>Experience: </b>%4")
+            .arg(gdr->get_skill_level_name(rating))
+            .arg(gdr->get_skill_name(skill_id))
+            .arg(QString::number((int)raw_rating))
+            .arg(d->get_skill(skill_id).exp_summary());
 
-            Skill s = d->get_skill(skill_id);
-            if(s.rust_level() > 0){
-                skill_str.append(QString("<br/><font color=%1><b>%2</b></font>")
-                                 .arg(s.rust_color().name())
-                                 .arg(Skill::get_rust_level_desc(s.rust_level())));
-            }
+        Skill s = d->get_skill(skill_id);
+        if(s.rust_level() > 0){
+            skill_str.append(QString("<br/><font color=%1><b>%2</b></font>")
+                    .arg(s.rust_color().name())
+                    .arg(Skill::get_rust_level_desc(s.rust_level())));
         }
     } else {
         // either the skill isn't a valid id, or they have 0 experience in it

--- a/src/uberdelegate.cpp
+++ b/src/uberdelegate.cpp
@@ -790,7 +790,7 @@ void UberDelegate::paint_mood_cell(const QRect &adjusted, QPainter *p, const QSt
 
     if(color_mood_cells && !dirty){ //dirty is always drawn over mood
         QList<Skill> skills = d->get_moodable_skills().values();
-        if((d->had_mood() || skills.count() > 1 ||  skills.at(0).capped_level() > -1) && d->get_moodable_skills().contains(skill_id)){
+        if(d->get_moodable_skills().contains(skill_id)){
             QColor mood = color_mood;
             if(d->had_mood())
                 mood = color_had_mood;

--- a/src/unitemotion.cpp
+++ b/src/unitemotion.cpp
@@ -103,7 +103,7 @@ UnitEmotion::UnitEmotion(VIRTADDR addr, DFInstance *df, QObject *parent)
                     QString key = re.cap(1);
                     QString replace = "";
                     if(key=="[skill]"){
-                        replace = gdr->get_skill_name(m_sub_id,false,(m_thought_id == 11));
+                        replace = gdr->get_skill_name(m_sub_id,(m_thought_id == 11));
                     }else if(key=="[building]"){
                         replace = gdr->get_building_name(static_cast<BUILDING_TYPE>(m_sub_id),m_optional_level);
                     }else if(key=="[syndrome]"){


### PR DESCRIPTION
Changed default of get_skill_name to noun, some use may need to change back to name.

Known uses of skill names/nouns:

| where                                                    | before          | now                    |
| -------------------------------------------------------- | --------------- | ---------------------- |
| dwarf tool-tip (highest moodable skill)  	               | noun (or empty) | noun (or Craftsdwarf)  |
| skill name (used in dwarf tool-tip/details/...)          | noun            | noun                   |
| caste description: bonuses                               | name            | noun                   |
| custom role dialog editor                                  | name            | noun                   |
| trait "Can(not) be a %2"                                 | name            | noun                   |
| uniform equipment skill (not sure if displayed anywhere) | name            | noun                   |
| activity "Lead/Watch [skill] Demonstration"              | name            | name                   |
| "Include social skills" tool-tip                         | name            | noun                   |
| script dialog: skill ID reference                        | name            | name                   |
| role tool-tip                                            | name            | noun                   |
| skill cell tool-tip: experience level                    | name            | noun                   |
| weapon cell tool-tip                                     | name            | noun                   |
| unit emotion	                                           | various         | unchanged              |
| custom grid view editor                                  | name            | noun                   |
