### PR TITLE
Compare view names instead of tab text

### DIFF
--- a/src/viewmanager.cpp
+++ b/src/viewmanager.cpp
@@ -452,7 +452,7 @@ void ViewManager::setCurrentIndex(int idx) {
 
     int sel_group = 0;
     foreach(GridView *v, m_views) {
-        if (v->name() == tabText(idx)) {
+        if (v->name() == stv->get_view_name()) {
             stv->is_loading_rows = true;
             stv->setSortingEnabled(false);
 


### PR DESCRIPTION
This fixes bug with Qt5 when KDE is installed:
https://bugreports.qt.io/browse/QTBUG-47696

Effectively if you have KDE installed your tabs will have ampersand in it's title which breaks string comparison.