### PR TITLE
Linux fix paths

### DIFF
--- a/src/dwarftherapist.cpp
+++ b/src/dwarftherapist.cpp
@@ -133,7 +133,7 @@ void DwarfTherapist::setup_search_paths() {
     // /usr/bin/../share/dwarftherapist/game_data.ini
 #ifdef Q_OS_LINUX
     for (auto loc : QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation))
-        paths << loc + "/dwarf-therapist";
+        paths << loc + "/dwarftherapist";
 #else
     paths << QStandardPaths::standardLocations(QStandardPaths::AppDataLocation);
 #endif

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -900,7 +900,7 @@ void MainWindow::open_help(){
     // Dwarf-Therapist/release/../doc/Dwarf Therapist.pdf
     doc_dirs << QString("%1/../doc").arg(appdir);
     // /usr/bin/../share/doc/dwarftherapist/Dwarf Therapist.pdf
-    doc_dirs << QString("%1/../share/dwarftherapist").arg(appdir);
+    doc_dirs << QString("%1/../share/doc/dwarftherapist").arg(appdir);
 
     QUrl url("http://dffd.wimbli.com/file.php?id=7889");
     foreach (const QString &dir, doc_dirs) {


### PR DESCRIPTION
Both commits fixes different issues with the paths to find data when doing `make install`.

https://github.com/Dwarf-Therapist/Dwarf-Therapist/commit/d8b63f40e8738486c295d847d517237315318eb6: On Linux the manual is installed into `/usr/share/doc/dwarftherapist`. The comment already indicated that this directory should be in the path but it wasn't. Didn't want to remove the existing line though in case it would break something

https://github.com/Dwarf-Therapist/Dwarf-Therapist/commit/b843d2104c8f9f43baf7e43345a1b6d0c1de771c: Memory layouts are installed into `/usr/share/dwarftherapist/memory_layouts`. However Dwarf Therapist on Linux is looking for them in different directories called `dwarf-therapist`. This fixes it. 