### PR TITLE
Revert "travis: use Qt 5.7 for OSX builds"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,12 @@ matrix:
     - os: osx
       before_install:
         - brew update
-        - brew install qt@5.7
+        - brew install qt@5.5
         - brew outdated cmake || brew upgrade cmake
         - brew install ninja
       env:
         - CXXFLAGS="$CXXFLAGS -mmacosx-version-min=10.9"
-        - QT_PREFIX=/usr/local/opt/qt@5.7
+        - QT_PREFIX=/usr/local/opt/qt@5.5
         - CMAKE_PREFIX_PATH=$QT_PREFIX
         - RELEASE_FILE='DwarfTherapist-*.dmg'
 env:


### PR DESCRIPTION
This reverts commit 33b1faa5703bacea93aa45f1d57c8f87427fbbc1.

fix #41 