### PR TITLE
gridviewdialog: use pointer as user data in QStandardItemModel

### DIFF
--- a/src/gridview.cpp
+++ b/src/gridview.cpp
@@ -139,20 +139,9 @@ GridView *GridView::read_from_ini(QSettings &s, QObject *parent) {
 void GridView::reorder_sets(const QStandardItemModel &model) {
     QList<ViewColumnSet*> new_sets;
     for (int i = 0; i < model.rowCount(); ++i) {
-        // find the set that matches this item in the GUI list
-        QStandardItem *item = model.item(i, 0);
-        QString name = item->data(GridViewDialog::GPDT_TITLE).toString();
-        foreach(ViewColumnSet *set, m_sets) {
-            if (set->name() == name) {
-                new_sets << set;
-                break;
-            }
-        }
+        new_sets << model.item(i,0)->data().value<ViewColumnSet *>();
     }
     Q_ASSERT(new_sets.size() == m_sets.size());
 
-    m_sets.clear();
-    foreach(ViewColumnSet *set, new_sets) {
-        m_sets << set;
-    }
+    m_sets = std::move(new_sets);
 }

--- a/src/gridviewdialog.h
+++ b/src/gridviewdialog.h
@@ -40,13 +40,6 @@ class GridViewDialog;
 class GridViewDialog : public QDialog {
     Q_OBJECT
 public:
-    typedef enum {
-        GPDT_TITLE = Qt::UserRole,
-        GPDT_BG_COLOR,
-        GPDT_OVERRIDE_BG_COLOR,
-        GPDT_WIDTH,
-        GPDT_COLUMN_TYPE
-    } GRIDVIEW_PENDING_DATA_TYPE;
     GridViewDialog(ViewManager *mgr, GridView *view, QWidget *parent = 0);
     virtual ~GridViewDialog();
 

--- a/src/viewcolumnset.cpp
+++ b/src/viewcolumnset.cpp
@@ -212,23 +212,11 @@ void ViewColumnSet::add_column(ViewColumn *col,int idx) {
 void ViewColumnSet::reorder_columns(const QStandardItemModel &model) {
     QList<ViewColumn*> new_cols;
     for (int i = 0; i < model.rowCount(); ++i) {
-        // find the VC that matches this item in the GUI list
-        QStandardItem *item = model.item(i, 0);
-        QString title = item->data(GridViewDialog::GPDT_TITLE).toString();
-        COLUMN_TYPE type = static_cast<COLUMN_TYPE>(item->data(GridViewDialog::GPDT_COLUMN_TYPE).toInt());
-        foreach(ViewColumn *vc, m_columns) {
-            if (vc->title() == title && vc->type() == type) {
-                new_cols << vc;
-                break;
-            }
-        }
+        new_cols << model.item(i, 0)->data().value<ViewColumn *>();
     }
     Q_ASSERT(new_cols.size() == m_columns.size());
 
-    m_columns.clear();
-    foreach(ViewColumn *vc, new_cols) {
-        m_columns << vc;
-    }
+    m_columns = std::move(new_cols);
 }
 
 void ViewColumnSet::read_settings(){


### PR DESCRIPTION
Search items by pointer instead of names, in case of name collision.

fix #21