### PR TITLE
Update help links

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -873,10 +873,10 @@ void MainWindow::draw_custom_profession_context_menu(const QPoint &p) {
 
 // web addresses
 void MainWindow::go_to_forums() {
-    QDesktopServices::openUrl(QUrl("http://www.bay12forums.com/smf/index.php?topic=122968.0"));
+    QDesktopServices::openUrl(QUrl("http://www.bay12forums.com/smf/index.php?topic=168411"));
 }
 void MainWindow::go_to_donate() {
-    QDesktopServices::openUrl(QUrl("https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=GM5Z6DYJEVW56&item_name=Donation"));
+    // No current donation link
 }
 void MainWindow::go_to_project_home() {
     QDesktopServices::openUrl(QUrl(DT->project_homepage()));

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -381,7 +381,6 @@
     <addaction name="act_go_latest_release"/>
     <addaction name="act_go_forums"/>
     <addaction name="act_go_new_issue"/>
-    <addaction name="act_go_donate"/>
     <addaction name="separator"/>
     <addaction name="act_about"/>
     <addaction name="act_check_update"/>


### PR DESCRIPTION
Old help actions linked to Splinterz's forum thread and paypal donation.

Forum thread link is updated and "Donate" action is hidden.

fix #66