### PR TITLE
Allow customize skills ui in tooltip

### DIFF
--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -2510,6 +2510,9 @@ QString Dwarf::tooltip_text() {
     if(!m_skills.isEmpty() && s->value("tooltip_show_skills",true).toBool()){
         int max_level = s->value("min_tooltip_skill_level", true).toInt();
         bool check_social = !s->value("tooltip_show_social_skills",true).toBool();
+        bool include_level = s->value("tooltip_show_skills_level",true).toBool();
+        bool include_exp_summary = s->value("tooltip_show_skills_exp_summary",true).toBool();
+        bool use_color = s->value("tooltip_show_skills_use_color",true).toBool();
         QMapIterator<float,int> i(m_sorted_skills);
         i.toBack();
         while(i.hasPrevious()){
@@ -2517,7 +2520,7 @@ QString Dwarf::tooltip_text() {
             if(m_skills.value(i.value()).capped_level() < max_level || (check_social && gdr->social_skills().contains(i.value()))) {
                 continue;
             }
-            skill_summary.append(QString("<li>%1</li>").arg(m_skills.value(i.value()).to_string()));
+            skill_summary.append(QString("<li>%1</li>").arg(m_skills.value(i.value()).to_string(include_level, include_exp_summary, use_color)));
         }
     }
 

--- a/src/optionsmenu.cpp
+++ b/src/optionsmenu.cpp
@@ -248,6 +248,9 @@ void OptionsMenu::tooltip_skills_toggled(bool checked){
     ui->lbl_max_tooltip_skills2->setEnabled(checked);
     ui->sb_min_skill_level->setEnabled(checked);
     ui->chk_show_social_skills->setEnabled(checked);
+    ui->chk_show_skills_level->setEnabled(checked);
+    ui->chk_show_skills_exp_summary->setEnabled(checked);
+    ui->chk_show_skills_use_color->setEnabled(checked);
 }
 
 void OptionsMenu::tooltip_roles_toggled(bool checked){
@@ -413,6 +416,9 @@ void OptionsMenu::read_settings() {
     ui->chk_show_skills->setChecked(s->value("tooltip_show_skills", true).toBool());
     ui->sb_min_skill_level->setValue(s->value("min_tooltip_skill_level",1).toInt());
     ui->chk_show_social_skills->setChecked(s->value("tooltip_show_social_skills",true).toBool());
+    ui->chk_show_skills_level->setChecked(s->value("tooltip_show_skills_level",true).toBool());
+    ui->chk_show_skills_exp_summary->setChecked(s->value("tooltip_show_skills_exp_summary",true).toBool());
+    ui->chk_show_skills_use_color->setChecked(s->value("tooltip_show_skills_use_color",true).toBool());
     tooltip_skills_toggled(ui->chk_show_skills->isChecked());
 
     ui->dsb_attribute_weight->setValue(s->value("default_attributes_weight",0.25).toDouble());
@@ -527,6 +533,9 @@ void OptionsMenu::write_settings() {
         s->setValue("tooltip_show_roles", ui->chk_show_roles->isChecked());
         s->setValue("tooltip_show_skills", ui->chk_show_skills->isChecked());
         s->setValue("tooltip_show_social_skills", ui->chk_show_social_skills->isChecked());
+        s->setValue("tooltip_show_skills_level", ui->chk_show_skills_level->isChecked());
+        s->setValue("tooltip_show_skills_exp_summary", ui->chk_show_skills_exp_summary->isChecked());
+        s->setValue("tooltip_show_skills_use_color", ui->chk_show_skills_use_color->isChecked());
         s->setValue("tooltip_show_artifact", ui->chk_show_artifact->isChecked());
         s->setValue("tooltip_show_mood", ui->chk_show_highest_mood->isChecked());
         s->setValue("tooltip_show_thoughts", ui->chk_show_thoughts->isChecked());
@@ -665,6 +674,9 @@ void OptionsMenu::restore_defaults() {
     ui->chk_show_roles->setChecked(true);
     ui->chk_show_skills->setChecked(true);
     ui->chk_show_social_skills->setChecked(true);
+    ui->chk_show_skills_level->setChecked(true);
+    ui->chk_show_skills_exp_summary->setChecked(true);
+    ui->chk_show_skills_use_color->setChecked(true);
     ui->chk_show_health->setChecked(false);
     ui->chk_health_colors->setChecked(true);
     ui->chk_health_symbols->setChecked(false);

--- a/src/optionsmenu.ui
+++ b/src/optionsmenu.ui
@@ -1699,7 +1699,7 @@
                </item>
               </layout>
              </item>
-             <item row="7" column="0">
+             <item row="10" column="0">
               <layout class="QHBoxLayout" name="horizontalLayout_10">
                <item>
                 <spacer name="horizontalSpacer_7">
@@ -1781,7 +1781,7 @@
                </item>
               </layout>
              </item>
-             <item row="6" column="0">
+             <item row="9" column="0">
               <widget class="QCheckBox" name="chk_show_roles">
                <property name="statusTip">
                 <string extracomment="When checked shows a list of roles and their respective ratings.">When checked shows a list of roles and their respective ratings.</string>
@@ -1804,7 +1804,7 @@
                </property>
               </widget>
              </item>
-             <item row="8" column="0">
+             <item row="11" column="0">
               <widget class="QCheckBox" name="chk_show_buffs">
                <property name="toolTip">
                 <string>When checked, shows the names of beneficial and negative syndromes in the tooltip.</string>
@@ -1840,7 +1840,7 @@
                </property>
               </widget>
              </item>
-             <item row="9" column="0">
+             <item row="12" column="0">
               <layout class="QHBoxLayout" name="horizontalLayout_21">
                <item>
                 <spacer name="horizontalSpacer_8">
@@ -1941,6 +1941,105 @@
                  </property>
                  <property name="text">
                   <string> thoughts/emotions in the tooltip.</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item row="6" column="0">
+              <layout class="QHBoxLayout" name="horizontalLayout_13">
+               <item>
+                <spacer name="horizontalSpacer_17">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Fixed</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="chk_show_skills_level">
+                 <property name="statusTip">
+                  <string>When checked, shows skill level in the tooltip.</string>
+                 </property>
+                 <property name="whatsThis">
+                  <string>When checked, shows skill level in the tooltip.</string>
+                 </property>
+                 <property name="text">
+                  <string>Show skill level</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item row="7" column="0">
+              <layout class="QHBoxLayout" name="horizontalLayout_14">
+               <item>
+                <spacer name="horizontalSpacer_18">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Fixed</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="chk_show_skills_exp_summary">
+                 <property name="statusTip">
+                  <string>When checked, shows skill experience value in the tooltip.</string>
+                 </property>
+                 <property name="whatsThis">
+                  <string>When checked, shows skill experience value in the tooltip.</string>
+                 </property>
+                 <property name="text">
+                  <string>Show skill experience</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item row="8" column="0">
+              <layout class="QHBoxLayout" name="horizontalLayout_15">
+               <item>
+                <spacer name="horizontalSpacer_19">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Fixed</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="chk_show_skills_use_color">
+                 <property name="statusTip">
+                  <string>When checked, highlights rusted skills in the tooltip.</string>
+                 </property>
+                 <property name="whatsThis">
+                  <string>When checked, highlights rusted skills in the tooltip.</string>
+                 </property>
+                 <property name="text">
+                  <string>Use color highlighting for skills</string>
                  </property>
                 </widget>
                </item>


### PR DESCRIPTION
![006](https://user-images.githubusercontent.com/29846693/41341922-4fa0e2c2-6f3e-11e8-9f4f-6e1eac34b037.png)
![007](https://user-images.githubusercontent.com/29846693/41341923-4ff9222a-6f3e-11e8-8198-7bfc5d63e28f.png)
Related to #97 
This is draft version, it work, but can be improved.