### PR TITLE
Fix a crash with out of bound stress level

### DIFF
--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -1871,7 +1871,7 @@ void Dwarf::read_emotions(VIRTADDR personality_base){
 
     auto gdr = GameDataReader::ptr();
     int i = 0;
-    while (i < DH_TOTAL_LEVELS &&
+    while (i < DH_TOTAL_LEVELS-1 &&
            m_stress_level < gdr->get_happiness_threshold(static_cast<DWARF_HAPPINESS>(i)))
          ++i;
     m_happiness = static_cast<DWARF_HAPPINESS>(i);


### PR DESCRIPTION
Stress can be under ecstatic threshold when using a wrong game_data.ini.
Ignore ecstatic threshold so the happiness level does not go beyond
that.