### PR TITLE
Fix usage of Dwarf::attribute and Dwarf::attribute_maximum in scripts

### DIFF
--- a/src/dwarf.h
+++ b/src/dwarf.h
@@ -269,8 +269,8 @@ public:
     Q_INVOKABLE int spatial_sense() {return attribute(AT_SPATIAL_SENSE);}
     Q_INVOKABLE int kinesthetic_sense() {return attribute(AT_KINESTHETIC_SENSE);}
     //! attribute value from id
-    Q_INVOKABLE int attribute(ATTRIBUTES_TYPE attrib_id) {return get_attribute(attrib_id).get_value();}
-    Q_INVOKABLE int attribute_maximum(ATTRIBUTES_TYPE attrib_id) {return (int)get_attribute(attrib_id).max();}
+    Q_INVOKABLE int attribute(int attrib_id) {return get_attribute(static_cast<ATTRIBUTES_TYPE>(attrib_id)).get_value();}
+    Q_INVOKABLE int attribute_maximum(int attrib_id) {return (int)get_attribute(static_cast<ATTRIBUTES_TYPE>(attrib_id)).max();}
     Attribute get_attribute(ATTRIBUTES_TYPE id);
 
     //! return this dwarf's squad reference id


### PR DESCRIPTION
Replaced enum argument with int so the value can be passed from scripts.

Fix #108 