### PR TITLE
Remove toolitip second columns when it is empty

### DIFF
--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -2736,9 +2736,12 @@ QString Dwarf::tooltip_text() {
 
     s->endGroup();
 
-    html.append(QString("<table><tr><td width=\"300\">%1</td><td width=\"600\">%2</td></tr></table>")
-                .arg(first_column)
-                .arg(second_column));
+    if (!second_column.isEmpty())
+        html.append(QString("<table><tr><td width=\"300\">%1</td><td width=\"600\">%2</td></tr></table>")
+                    .arg(first_column)
+                    .arg(second_column));
+    else
+        html.append(first_column);
     return html;
 }
 


### PR DESCRIPTION
Animals usually don't have a second columns. Remove it when it is empty,
so there is not a big empty space on the right of the tooltip.

fix #110