### PR TITLE
Fix IS_ARMOR and IS_CLOTHING flags

### DIFF
--- a/src/itemsubtype.h
+++ b/src/itemsubtype.h
@@ -36,8 +36,8 @@ enum ITEMDEF_FLAG
     ITEM_INCOMPLETE = 1000,
     ITEM_MELEE_WEAPON,
     ITEM_RANGED_WEAPON,
-    ITEM_IS_ARMOR = 1003, // value fixed for backward compatibility
-    ITEM_IS_CLOTHING = 1004,
+    ITEM_IS_CLOTHING = 1003, // value fixed for backward compatibility
+    ITEM_IS_ARMOR = 1004,
     // flags based on the ITEM_TYPE
     ITEM_TYPE_IS_TRADE_GOOD = 1005,
     ITEM_TYPE_IS_EQUIPMENT,


### PR DESCRIPTION
IS_ARMOR and IS_CLOTHING flags where inverted in
ce9a403d5541858501be5bf33bddd6096848be77. This fixes compatiblity with
older versions but breaks roles and columns created since the error was
made.

fix #118