### PR TITLE
Add style option

### DIFF
--- a/src/dwarftherapist.cpp
+++ b/src/dwarftherapist.cpp
@@ -44,6 +44,7 @@ THE SOFTWARE.
 #include "standardpaths.h"
 #include <QMessageBox>
 #include <QSettings>
+#include <QStyleFactory>
 #include <QToolTip>
 #include <QTranslator>
 #include <QTimer>
@@ -272,6 +273,10 @@ void DwarfTherapist::read_settings() {
     }
     m_user_settings->endGroup();//happiness
     m_user_settings->endGroup();//colors
+
+    //set current style
+    if (m_user_settings->contains("style"))
+        setStyle(m_user_settings->value("style").toString());
 
     //set the application fonts
     QApplication::setFont(DT->user_settings()->value("main_font", QFont(DefaultFonts::getMainFontName(), DefaultFonts::getMainFontSize())).value<QFont>());

--- a/src/optionsmenu.cpp
+++ b/src/optionsmenu.cpp
@@ -38,6 +38,7 @@ THE SOFTWARE.
 
 #include <QMessageBox>
 #include <QSettings>
+#include <QStyleFactory>
 #include <QFontDialog>
 
 const QStringList OptionsMenu::m_msg_vars = QStringList() << MSG_WARN_READ << MSG_LIVESTOCK;
@@ -48,6 +49,9 @@ OptionsMenu::OptionsMenu(QWidget *parent)
     , m_reading_settings(false)
 {
     ui->setupUi(this);
+
+    ui->cb_style->addItem(tr("Default"));
+    ui->cb_style->addItems(QStyleFactory::keys());
 
     m_general_colors
             << new CustomColor(tr("Skill"),
@@ -354,6 +358,13 @@ void OptionsMenu::read_settings() {
     m_tooltip_font = qMakePair(temp,temp);
     show_current_font(temp,ui->lbl_current_tooltip);
 
+    auto current_style = s->value("style").toString();
+    int current_style_index = ui->cb_style->findText(current_style);
+    if (current_style_index != -1)
+        ui->cb_style->setCurrentIndex(current_style_index);
+    else
+        ui->cb_style->setCurrentIndex(0); // first item is "default" style
+
     temp = s->value("main_font", QFont(DefaultFonts::getMainFontName(), DefaultFonts::getMainFontSize())).value<QFont>();
     m_main_font = qMakePair(temp,temp);
     show_current_font(temp,ui->lbl_current_main_font);
@@ -532,6 +543,10 @@ void OptionsMenu::write_settings() {
         s->setValue("animal_health", ui->cb_animal_health->isChecked());
         s->setValue("tooltip_font", m_tooltip_font.first);
         s->setValue("main_font", m_main_font.first);
+        if (ui->cb_style->currentIndex() == 0)
+            s->remove("style");
+        else
+            s->setValue("style", ui->cb_style->currentText());
         s->setValue("gender_info", ui->cb_gender_info->currentData());
 
         s->setValue("overwrite_default_attributes_weight",ui->cb_attribute_weight->isChecked());

--- a/src/optionsmenu.ui
+++ b/src/optionsmenu.ui
@@ -321,6 +321,39 @@
            </item>
           </layout>
          </item>
+         <item row="0" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout_17">
+           <item>
+            <widget class="QLabel" name="lbl_style">
+             <property name="toolTip">
+              <string>Change the global style of the application. The new style may not be applied fully until the application is restarted.</string>
+             </property>
+             <property name="statusTip">
+              <string>Change the global style of the application. The new style may not be applied fully until the application is restarted.</string>
+             </property>
+             <property name="whatsThis">
+              <string>Change the global style of the application. The new style may not be applied fully until the application is restarted.</string>
+             </property>
+             <property name="text">
+              <string>Style: </string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="cb_style">
+             <property name="toolTip">
+              <string>Change the global style of the application. The new style may not be applied fully until the application is restarted.</string>
+             </property>
+             <property name="statusTip">
+              <string>Change the global style of the application. The new style may not be applied fully until the application is restarted.</string>
+             </property>
+             <property name="whatsThis">
+              <string>Change the global style of the application. The new style may not be applied fully until the application is restarted.</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
         </layout>
        </item>
        <item>


### PR DESCRIPTION
Let choose the style from the option menu and store it in the settings.

In the current state, if the stored style value is not found in the QStyleFactory keys, the combo box may not be set accordingly and the style may change when accepting the option dialog.