### PR TITLE
Rename Trade Goods/Water Hauling labors

### DIFF
--- a/resources/game_data.ini
+++ b/resources/game_data.ini
@@ -1022,7 +1022,7 @@ size = 83
 74/skill = -1
 74/hauling = 1
 
-75/name = Haul Trade Goods
+75/name = Trade Good Hauling
 75/id = 74
 75/skill = -1
 75/hauling = 1
@@ -1037,7 +1037,7 @@ size = 83
 77/skill = -1
 77/hauling = 1
 
-78/name = Haul Water
+78/name = Water Hauling
 78/id = 77
 78/skill = -1
 78/hauling = 1


### PR DESCRIPTION
The names were inconsistent with other hauling labors.

Fix #159 