### PR TITLE
Move log file to a standard path

### DIFF
--- a/src/dfinstanceosx.mm
+++ b/src/dfinstanceosx.mm
@@ -63,6 +63,10 @@ DFInstanceOSX::DFInstanceOSX(QObject* parent)
     , m_alloc_end(0)
     , m_ruid(getuid())
 {
+    // Try to reacquire root privileges, don't check success,
+    // authorize() will handle that
+    seteuid(0);
+
     // This makes the unauthorized DT instance quit at the proper time.
     // No, fflush(stdout) does not work.
     puts("");

--- a/src/dwarftherapist.cpp
+++ b/src/dwarftherapist.cpp
@@ -198,21 +198,16 @@ void DwarfTherapist::setup_logging(const QString &path, bool debug_logging, bool
     else
         log_file = path;
 
-    TruncatingFileLogger *log = m_log_mgr->add_logger(log_file);
-    if (log) {
-        LogAppender *app = m_log_mgr->add_appender("core", log, LL_TRACE);
-        if (app) {
-            Version v; // current version
-            LOGI << "Dwarf Therapist" << v.to_string() << "starting normally.";
-            LOGI << "Runtime QT Version" << qVersion();
-            //app->set_minimum_level(min_level);
-            app->set_minimum_level(min_level);
-        } else {
-            qCritical() << "Could not open logfile!";
-            qApp->exit(1);
-        }
-    } else {
-        qCritical() << "Could not open logfile!";
+    LogAppender *app = m_log_mgr->add_appender("core", LL_TRACE);
+    try {
+        app->add_file_logger(log_file);
+        app->add_stderr_logger();
+        Version v; // current version
+        LOGI << "Dwarf Therapist" << v.to_string() << "starting normally.";
+        LOGI << "Runtime QT Version" << qVersion();
+        app->set_minimum_level(min_level);
+    } catch (std::exception &e) {
+        qCritical() << e.what();
         qApp->exit(1);
     }
 }

--- a/src/dwarftherapist.cpp
+++ b/src/dwarftherapist.cpp
@@ -49,6 +49,10 @@ THE SOFTWARE.
 #include <QTimer>
 #include <QCommandLineParser>
 
+#ifdef Q_OS_OSX
+#include <unistd.h>
+#endif
+
 const QString DwarfTherapist::m_url_homepage = QString("https://github.com/%1/%2").arg(REPO_OWNER).arg(REPO_NAME);
 
 DwarfTherapist::DwarfTherapist(int &argc, char **argv)
@@ -66,6 +70,11 @@ DwarfTherapist::DwarfTherapist(int &argc, char **argv)
     , m_arena_mode(false) //manually set this to true to do arena testing (very hackish, all units will be animals)
     , m_log_mgr(0)
 {
+#ifdef Q_OS_OSX
+    // Drop root privileges early, they will be reacquired when needed
+    seteuid(getuid());
+#endif
+
 #ifdef Q_OS_LINUX
     // Linux prefers lower case and no space in package names.
     setApplicationName("dwarftherapist");

--- a/src/dwarftherapist.h
+++ b/src/dwarftherapist.h
@@ -154,7 +154,7 @@ private:
     static const QString m_url_homepage;
 
     void setup_search_paths();
-    void setup_logging(bool debug_logging, bool trace_logging);
+    void setup_logging(const QString &path, bool debug_logging, bool trace_logging);
     void load_translator();
     void edit_customization(QList<QVariant> data);
     void check_global_color(GLOBAL_COLOR_TYPES key, QString setting_key, QString title, QString desc, QColor col_default);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -944,6 +944,11 @@ void MainWindow::open_data_dir() {
     QDesktopServices::openUrl(QUrl::fromLocalFile(data_dir.path()));
 }
 
+void MainWindow::open_log_dir() {
+    QDir log_dir = StandardPaths::log_location();
+    QDesktopServices::openUrl(QUrl::fromLocalFile(log_dir.path()));
+}
+
 void MainWindow::open_help(){
     QUrl url("http://dffd.wimbli.com/file.php?id=7889");
     foreach (const QString &dir, StandardPaths::doc_locations()) {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -121,6 +121,7 @@ public slots:
     void go_to_latest_release();
     void check_latest_version();
     void open_data_dir();
+    void open_log_dir();
 
     //help
     void open_help();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -360,6 +360,7 @@
     <addaction name="act_import_saved_gridviews"/>
     <addaction name="separator"/>
     <addaction name="act_open_data_dir"/>
+    <addaction name="act_open_log_dir"/>
     <addaction name="separator"/>
     <addaction name="act_print"/>
     <addaction name="separator"/>
@@ -1187,6 +1188,14 @@
     <string>Open directory for custom data files in the file explorer</string>
    </property>
   </action>
+  <action name="act_open_log_dir">
+   <property name="text">
+    <string>Open log directory</string>
+   </property>
+   <property name="toolTip">
+    <string>Open directory containing log files in the file explorer</string>
+   </property>
+  </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
@@ -1691,6 +1700,22 @@
    <signal>triggered()</signal>
    <receiver>MainWindow</receiver>
    <slot>open_data_dir()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>629</x>
+     <y>257</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>act_open_log_dir</sender>
+   <signal>triggered()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>open_log_dir()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>-1</x>

--- a/src/standardpaths.cpp
+++ b/src/standardpaths.cpp
@@ -140,6 +140,30 @@ QString StandardPaths::writable_data_location()
     }
 }
 
+QString StandardPaths::log_location()
+{
+    switch (mode) {
+    case Mode::Portable:
+    case Mode::Developer:
+        return appdir.path();
+    case Mode::Standard:
+    default:
+#if (defined Q_OS_WIN)
+        return QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation)
+            + "\\log";
+#elif (defined Q_OS_OSX)
+        return QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
+            + "/Library/Logs/"
+            + QCoreApplication::applicationName();
+#elif (defined Q_OS_LINUX)
+        return QStandardPaths::writableLocation(QStandardPaths::CacheLocation)
+            + "/log";
+#else
+#   error "Unsupported OS"
+#endif
+    }
+}
+
 QStringList StandardPaths::doc_locations()
 {
     switch (mode) {

--- a/src/standardpaths.h
+++ b/src/standardpaths.h
@@ -51,6 +51,7 @@ public:
     static QString locate_data(const QString &filename);
     static QStringList data_locations();
     static QString writable_data_location();
+    static QString log_location();
     static QStringList doc_locations();
 
 private:


### PR DESCRIPTION
New default location are:
 - Windows: %APPDATA%/Local/Dwarf Therapist/dwarftherapist.log
 - macOS: ~/Library/Logs/io.github.dwarf-therapist/dwarftherapist.log
 - Linux: no log file
Portable/developer modes stores the log in the application directory.

Log path can be overriden using the "--log=<path>" option.