### PR TITLE
Stats fix

### DIFF
--- a/src/dwarf.h
+++ b/src/dwarf.h
@@ -205,9 +205,9 @@ public:
     Q_INVOKABLE bool is_pet() {return m_is_pet;}
     Q_INVOKABLE TRAINED_LEVEL trained_level() {return m_animal_type;}
 
-    Q_INVOKABLE bool is_adult() {return (!m_is_child && !m_is_baby) ? true : false;}
-    Q_INVOKABLE bool is_child() {return m_is_child;}
-    Q_INVOKABLE bool is_baby() {return m_is_baby;}
+    Q_INVOKABLE bool is_adult() {return !is_child() && !is_baby();}
+    Q_INVOKABLE bool is_child() {return m_raw_prof_id == 103;}
+    Q_INVOKABLE bool is_baby() {return m_raw_prof_id == 104;}
 
     Q_INVOKABLE bool is_citizen() {return m_is_citizen;}
 
@@ -719,8 +719,6 @@ private:
     QList<short> m_thoughts;
     QList<UnitEmotion*> m_emotions;
     QString m_emotions_desc;
-    bool m_is_child;
-    bool m_is_baby;
     bool m_is_animal;
     QString m_true_name; //used for vampires
     int m_true_birth_year; //used for vampires

--- a/src/dwarfstats.cpp
+++ b/src/dwarfstats.cpp
@@ -79,6 +79,9 @@ void DwarfStats::init(const QVector<double> &values)
 
 double DwarfStats::rating(double val) const
 {
-    return m_stats->get_rating(val);
+    if (m_stats)
+        return m_stats->get_rating(val);
+    else
+        return 0.5;
 }
 


### PR DESCRIPTION
fixes #199 

Now all "can_set_labors" units are included in the "labor-capable dwarves" stats. Along with any adult (that should include visitors/mercenaries too).

Or should non-citizens be checked by profession instead of age too?