### PR TITLE
Make DwarfTherapist::get_main_window safer

### DIFF
--- a/src/dwarftherapist.cpp
+++ b/src/dwarftherapist.cpp
@@ -164,11 +164,21 @@ DwarfTherapist::~DwarfTherapist(){
 }
 
 MainWindow* DwarfTherapist::get_main_window(){
-    return m_main_window;
+    if (!m_main_window) {
+        for (auto widget: topLevelWidgets())
+            if (auto main_window = qobject_cast<MainWindow *>(widget))
+                return main_window;
+        return nullptr;
+    }
+    else
+        return m_main_window;
 }
 
 DFInstance* DwarfTherapist::get_DFInstance(){
-    return m_main_window->get_DFInstance();
+    if (m_main_window)
+        return m_main_window->get_DFInstance();
+    else
+        return nullptr;
 }
 
 void DwarfTherapist::setup_logging(const QString &path, bool debug_logging, bool trace_logging) {

--- a/src/notifierwidget.cpp
+++ b/src/notifierwidget.cpp
@@ -76,9 +76,9 @@ void NotifierWidget::reposition(){
         QPoint mainwindow_br = this->parentWidget()->frameGeometry().bottomRight();
         //padding to set it above the status bar
         QSize pad(12,32);
-        if(DT->get_main_window()->statusBar()){
-            pad.setHeight(DT->get_main_window()->statusBar()->height()+10);
-        }
+        if (auto main_window = DT->get_main_window())
+            if (main_window->statusBar())
+                pad.setHeight(main_window->statusBar()->height()+10);
         mainwindow_br.setY(mainwindow_br.y()-pad.height());
         mainwindow_br.setX(mainwindow_br.x()-pad.width());
         QRect this_geo = this->frameGeometry();


### PR DESCRIPTION
During MainWindow constructor m_main_window is not set but
get_main_window may still be called.

fix #237