### PR TITLE
Set correct file ownership for Dwarf Therapist.ini in OSX

### DIFF
--- a/src/dfinstanceosx.h
+++ b/src/dfinstanceosx.h
@@ -51,6 +51,7 @@ protected:
     bool set_pid();
 
 private:
+    bool drop_privileges() const;
     VIRTADDR alloc_chunk(USIZE size);
     VIRTADDR m_alloc_start, m_alloc_end;
     int m_alloc_remaining, m_size_allocated;

--- a/src/standardpaths.cpp
+++ b/src/standardpaths.cpp
@@ -26,10 +26,6 @@ THE SOFTWARE.
 #include <QStandardPaths>
 #include <QCoreApplication>
 
-#ifdef Q_OS_OSX
-#include <unistd.h>
-#endif
-
 constexpr StandardPaths::Mode StandardPaths::DefaultMode;
 
 StandardPaths::Mode StandardPaths::mode;
@@ -75,12 +71,11 @@ void StandardPaths::init_paths(Mode mode, QString source_datadir)
 
 std::unique_ptr<QSettings> StandardPaths::settings()
 {
-    std::unique_ptr<QSettings> qSettings;
     switch (mode) {
     case Mode::Portable:
     case Mode::Developer: {
         auto ini_file = QString("%1.ini").arg(QCoreApplication::applicationName());
-        qSettings = std::make_unique<QSettings>(custom_configdir.filePath(ini_file),
+        return std::make_unique<QSettings>(custom_configdir.filePath(ini_file),
                                            QSettings::IniFormat);
     }
     case Mode::Standard:
@@ -88,17 +83,10 @@ std::unique_ptr<QSettings> StandardPaths::settings()
         // Organization is not set on Linux/Windows to avoid issue with QStandardPaths
         // using "orgname/appname" folder instead "packagename". Force QSettings
         // to use the application name for the configuration directory.
-        qSettings = std::make_unique<QSettings>(QSettings::IniFormat, QSettings::UserScope,
-                                                QCoreApplication::applicationName(),
-                                                QCoreApplication::applicationName());
+        return std::make_unique<QSettings>(QSettings::IniFormat, QSettings::UserScope,
+                                           QCoreApplication::applicationName(),
+                                           QCoreApplication::applicationName());
     }
-
-#ifdef Q_OS_OSX
-    QByteArray fileName = qSettings->fileName().toLocal8Bit();
-    chown(fileName.data(), getuid(), getgid());
-#endif
-
-    return qSettings;
 }
 
 QString StandardPaths::locate_data(const QString &filename)


### PR DESCRIPTION
The reason settings aren't saved properly in OSX is because the config
file ends up getting owned by root. Changing the ownership in between
runs doesn't work because QT's default method of writing a file creates
a temp file (which will be owned by root if the settings sync when
running as root) which it then copies over the original file. We can fix
this by simply changing the file ownership to the current UID and GID
after we construct a `QSettings` object, which is when this generally
seems to happen.

Fixes #72.
