### PR TITLE
Update wording on orientation info to 0.47.01

### DIFF
--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -509,7 +509,7 @@ void Dwarf::read_gender_orientation() {
     if (show_orientation)
         gender_desc << get_orientation_desc(m_gender_info.orientation);
     if (show_commitment) {
-        static const QStringList preferences = { tr("Not interested in %1"), tr("Likes %1"), tr("Will marry %1") };
+        static const QStringList preferences = { tr("Not interested in %1"), tr("Likes %1"), tr("Prefers %1") };
         for (const auto &t: {
                 std::make_tuple(m_gender_info.male, tr("males")),
                 std::make_tuple(m_gender_info.female, tr("females")) }) {


### PR DESCRIPTION
As of 0.47.01, dwarves can now marry even if they don't have the "will marry" flag. I assume it's not a commitment thing so much as a preference thing now, so the wording has been updated to change that. The icons should probably be updated too, since the current impression given is that they're non-breeding if they have the "lover" flag instead of the "marry" flag for the opposite sex, which is simply not the case.