### PR TITLE
Hide commitment in sexual orientation details

### DIFF
--- a/src/dwarf.cpp
+++ b/src/dwarf.cpp
@@ -436,7 +436,8 @@ void Dwarf::read_gender_orientation() {
     QSettings *s = DT->user_settings();
     auto gender_info_option = s->value("options/gender_info", Option_ShowOrientation).toInt();
     bool show_orientation = gender_info_option >= Option_ShowOrientation;
-    bool show_commitment = !m_is_animal && gender_info_option >= Option_ShowCommitment;
+    //bool show_commitment = !m_is_animal && gender_info_option >= Option_ShowCommitment;
+    bool show_commitment = false; // hide commitment until it is better understood
 
     BYTE sex = m_df->read_byte(m_mem->dwarf_field(m_address, "sex"));
     TRACE << "GENDER:" << sex;

--- a/src/optionsmenu.cpp
+++ b/src/optionsmenu.cpp
@@ -133,7 +133,8 @@ OptionsMenu::OptionsMenu(QWidget *parent)
 
     ui->cb_gender_info->addItem(tr("Sex only"), Dwarf::Option_SexOnly);
     ui->cb_gender_info->addItem(tr("Show orientation"), Dwarf::Option_ShowOrientation);
-    ui->cb_gender_info->addItem(tr("Show orientation + commitment"), Dwarf::Option_ShowCommitment);
+    // hide commitment until it is better understood
+    //ui->cb_gender_info->addItem(tr("Show orientation + commitment"), Dwarf::Option_ShowCommitment);
 
     ui->cb_skill_drawing_method->addItem("Growing Center Box", UberDelegate::SDM_GROWING_CENTRAL_BOX);
     ui->cb_skill_drawing_method->addItem("Line Glyphs", UberDelegate::SDM_GLYPH_LINES);
@@ -306,6 +307,8 @@ void OptionsMenu::read_settings() {
     show_current_font(temp,ui->lbl_current_main_font);
 
     idx = ui->cb_gender_info->findData(s->value("gender_info", Dwarf::Option_ShowOrientation));
+    if (idx == -1) // fallback to default if stored setting has been removed
+        idx = ui->cb_gender_info->findData(Dwarf::Option_ShowOrientation);
     ui->cb_gender_info->setCurrentIndex(idx);
 
     ui->cb_read_dwarves_on_startup->setChecked(s->value("read_on_startup", true).toBool());


### PR DESCRIPTION
It is not known what it does in the current version. Hide it until the proper wording is found.

replaces #262

@Putnam3145 do you agree with this?