### PR TITLE
Bump CMake minimal required version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5.0 FATAL_ERROR)
 project(DwarfTherapist)
 
 set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
CMake versions < 3.5 will be deprecated in the next CMake release. If you bump CMake version to at least 3.5, everything still compiles, it seems, and it resolves the deprecation warnings when compiling.