### PR TITLE
Update memory layout format

### DIFF
--- a/share/memory_layouts/linux/v0.50.10-classic_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.10-classic_linux64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/linux/v0.50.10-classic_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.10-classic_linux64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/linux/v0.50.10-itch_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.10-itch_linux64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/linux/v0.50.10-itch_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.10-itch_linux64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/linux/v0.50.10-steam_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.10-steam_linux64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/linux/v0.50.10-steam_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.10-steam_linux64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/linux/v0.50.11-classic_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.11-classic_linux64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/linux/v0.50.11-classic_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.11-classic_linux64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/linux/v0.50.11-itch_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.11-itch_linux64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/linux/v0.50.11-itch_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.11-itch_linux64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/linux/v0.50.11-steam_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.11-steam_linux64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/linux/v0.50.11-steam_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.11-steam_linux64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/linux/v0.50.12-classic_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.12-classic_linux64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/linux/v0.50.12-classic_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.12-classic_linux64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/linux/v0.50.12-itch_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.12-itch_linux64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/linux/v0.50.12-itch_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.12-itch_linux64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/linux/v0.50.12-steam_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.12-steam_linux64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/linux/v0.50.12-steam_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.12-steam_linux64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/linux/v0.50.13-classic_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.13-classic_linux64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_item_type=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 
@@ -412,25 +410,23 @@ setupdwarfgame_units=0x1f08
 size=0
 
 [invalid_flags_1]
-size=9
-1\name="a skeleton"
-1\value=0x00002000
-2\name="a merchant"
-2\value=0x00000040
-3\name="outpost liaison, diplomat, or artifact requesting visitor"
-3\value=0x00000800
+size=8
+1\name="a merchant"
+1\value=0x00000040
+2\name="outpost liaison, diplomat, or artifact requesting visitor"
+2\value=0x00000800
+3\name="an invader or hostile"
+3\value=0x00020000
 4\name="an invader or hostile"
-4\value=0x00020000
-5\name="an invader or hostile"
-5\value=0x00080000
-6\name="resident, invader or ambusher"
-6\value=0x00600000
-7\name="part of a merchant caravan"
-7\value=0x00000080
-8\name="inactive, currently not in play"
-8\value=0x00000002
-9\name="marauder"
-9\value=0x00000010
+4\value=0x00080000
+5\name="resident, invader or ambusher"
+5\value=0x00600000
+6\name="part of a merchant caravan"
+6\value=0x00000080
+7\name="inactive, currently not in play"
+7\value=0x00000002
+8\name="marauder"
+8\value=0x00000010
 
 [invalid_flags_2]
 size=5

--- a/share/memory_layouts/linux/v0.50.13-classic_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.13-classic_linux64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/linux/v0.50.13-itch_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.13-itch_linux64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_item_type=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 
@@ -412,25 +410,23 @@ setupdwarfgame_units=0x1f08
 size=0
 
 [invalid_flags_1]
-size=9
-1\name="a skeleton"
-1\value=0x00002000
-2\name="a merchant"
-2\value=0x00000040
-3\name="outpost liaison, diplomat, or artifact requesting visitor"
-3\value=0x00000800
+size=8
+1\name="a merchant"
+1\value=0x00000040
+2\name="outpost liaison, diplomat, or artifact requesting visitor"
+2\value=0x00000800
+3\name="an invader or hostile"
+3\value=0x00020000
 4\name="an invader or hostile"
-4\value=0x00020000
-5\name="an invader or hostile"
-5\value=0x00080000
-6\name="resident, invader or ambusher"
-6\value=0x00600000
-7\name="part of a merchant caravan"
-7\value=0x00000080
-8\name="inactive, currently not in play"
-8\value=0x00000002
-9\name="marauder"
-9\value=0x00000010
+4\value=0x00080000
+5\name="resident, invader or ambusher"
+5\value=0x00600000
+6\name="part of a merchant caravan"
+6\value=0x00000080
+7\name="inactive, currently not in play"
+7\value=0x00000002
+8\name="marauder"
+8\value=0x00000010
 
 [invalid_flags_2]
 size=5

--- a/share/memory_layouts/linux/v0.50.13-itch_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.13-itch_linux64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/linux/v0.50.13-steam_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.13-steam_linux64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_item_type=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 
@@ -412,25 +410,23 @@ setupdwarfgame_units=0x1f08
 size=0
 
 [invalid_flags_1]
-size=9
-1\name="a skeleton"
-1\value=0x00002000
-2\name="a merchant"
-2\value=0x00000040
-3\name="outpost liaison, diplomat, or artifact requesting visitor"
-3\value=0x00000800
+size=8
+1\name="a merchant"
+1\value=0x00000040
+2\name="outpost liaison, diplomat, or artifact requesting visitor"
+2\value=0x00000800
+3\name="an invader or hostile"
+3\value=0x00020000
 4\name="an invader or hostile"
-4\value=0x00020000
-5\name="an invader or hostile"
-5\value=0x00080000
-6\name="resident, invader or ambusher"
-6\value=0x00600000
-7\name="part of a merchant caravan"
-7\value=0x00000080
-8\name="inactive, currently not in play"
-8\value=0x00000002
-9\name="marauder"
-9\value=0x00000010
+4\value=0x00080000
+5\name="resident, invader or ambusher"
+5\value=0x00600000
+6\name="part of a merchant caravan"
+6\value=0x00000080
+7\name="inactive, currently not in play"
+7\value=0x00000002
+8\name="marauder"
+8\value=0x00000010
 
 [invalid_flags_2]
 size=5

--- a/share/memory_layouts/linux/v0.50.13-steam_linux64.ini
+++ b/share/memory_layouts/linux/v0.50.13-steam_linux64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.04-steam_win64.ini
+++ b/share/memory_layouts/windows/v0.50.04-steam_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.04-steam_win64.ini
+++ b/share/memory_layouts/windows/v0.50.04-steam_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.05-steam_win64.ini
+++ b/share/memory_layouts/windows/v0.50.05-steam_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.05-steam_win64.ini
+++ b/share/memory_layouts/windows/v0.50.05-steam_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.07-classic_win64.ini
+++ b/share/memory_layouts/windows/v0.50.07-classic_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.07-classic_win64.ini
+++ b/share/memory_layouts/windows/v0.50.07-classic_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.07-itch_win64.ini
+++ b/share/memory_layouts/windows/v0.50.07-itch_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.07-itch_win64.ini
+++ b/share/memory_layouts/windows/v0.50.07-itch_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.07-steam_win64.ini
+++ b/share/memory_layouts/windows/v0.50.07-steam_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.07-steam_win64.ini
+++ b/share/memory_layouts/windows/v0.50.07-steam_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.08-classic_win64.ini
+++ b/share/memory_layouts/windows/v0.50.08-classic_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.08-classic_win64.ini
+++ b/share/memory_layouts/windows/v0.50.08-classic_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.08-itch_win64.ini
+++ b/share/memory_layouts/windows/v0.50.08-itch_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.08-itch_win64.ini
+++ b/share/memory_layouts/windows/v0.50.08-itch_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.08-steam_win64.ini
+++ b/share/memory_layouts/windows/v0.50.08-steam_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.08-steam_win64.ini
+++ b/share/memory_layouts/windows/v0.50.08-steam_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.09-classic_win64.ini
+++ b/share/memory_layouts/windows/v0.50.09-classic_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.09-classic_win64.ini
+++ b/share/memory_layouts/windows/v0.50.09-classic_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.09-itch_win64.ini
+++ b/share/memory_layouts/windows/v0.50.09-itch_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.09-itch_win64.ini
+++ b/share/memory_layouts/windows/v0.50.09-itch_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.09-steam_win64.ini
+++ b/share/memory_layouts/windows/v0.50.09-steam_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.09-steam_win64.ini
+++ b/share/memory_layouts/windows/v0.50.09-steam_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.10-classic_win64.ini
+++ b/share/memory_layouts/windows/v0.50.10-classic_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.10-classic_win64.ini
+++ b/share/memory_layouts/windows/v0.50.10-classic_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.10-itch_win64.ini
+++ b/share/memory_layouts/windows/v0.50.10-itch_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.10-itch_win64.ini
+++ b/share/memory_layouts/windows/v0.50.10-itch_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.10-steam_win64.ini
+++ b/share/memory_layouts/windows/v0.50.10-steam_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.10-steam_win64.ini
+++ b/share/memory_layouts/windows/v0.50.10-steam_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.11-classic_win64.ini
+++ b/share/memory_layouts/windows/v0.50.11-classic_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.11-classic_win64.ini
+++ b/share/memory_layouts/windows/v0.50.11-classic_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.11-itch_win64.ini
+++ b/share/memory_layouts/windows/v0.50.11-itch_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.11-itch_win64.ini
+++ b/share/memory_layouts/windows/v0.50.11-itch_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.11-steam_win64.ini
+++ b/share/memory_layouts/windows/v0.50.11-steam_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.11-steam_win64.ini
+++ b/share/memory_layouts/windows/v0.50.11-steam_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.12-classic_win64.ini
+++ b/share/memory_layouts/windows/v0.50.12-classic_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.12-classic_win64.ini
+++ b/share/memory_layouts/windows/v0.50.12-classic_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.12-itch_win64.ini
+++ b/share/memory_layouts/windows/v0.50.12-itch_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.12-itch_win64.ini
+++ b/share/memory_layouts/windows/v0.50.12-itch_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.12-steam_win64.ini
+++ b/share/memory_layouts/windows/v0.50.12-steam_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.12-steam_win64.ini
+++ b/share/memory_layouts/windows/v0.50.12-steam_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_uniform_item_filter=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.13-classic_win64.ini
+++ b/share/memory_layouts/windows/v0.50.13-classic_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_item_type=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 
@@ -412,25 +410,23 @@ setupdwarfgame_units=0x1ee8
 size=0
 
 [invalid_flags_1]
-size=9
-1\name="a skeleton"
-1\value=0x00002000
-2\name="a merchant"
-2\value=0x00000040
-3\name="outpost liaison, diplomat, or artifact requesting visitor"
-3\value=0x00000800
+size=8
+1\name="a merchant"
+1\value=0x00000040
+2\name="outpost liaison, diplomat, or artifact requesting visitor"
+2\value=0x00000800
+3\name="an invader or hostile"
+3\value=0x00020000
 4\name="an invader or hostile"
-4\value=0x00020000
-5\name="an invader or hostile"
-5\value=0x00080000
-6\name="resident, invader or ambusher"
-6\value=0x00600000
-7\name="part of a merchant caravan"
-7\value=0x00000080
-8\name="inactive, currently not in play"
-8\value=0x00000002
-9\name="marauder"
-9\value=0x00000010
+4\value=0x00080000
+5\name="resident, invader or ambusher"
+5\value=0x00600000
+6\name="part of a merchant caravan"
+6\value=0x00000080
+7\name="inactive, currently not in play"
+7\value=0x00000002
+8\name="marauder"
+8\value=0x00000010
 
 [invalid_flags_2]
 size=5

--- a/share/memory_layouts/windows/v0.50.13-classic_win64.ini
+++ b/share/memory_layouts/windows/v0.50.13-classic_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.13-itch_win64.ini
+++ b/share/memory_layouts/windows/v0.50.13-itch_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_item_type=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 
@@ -412,25 +410,23 @@ setupdwarfgame_units=0x1ee8
 size=0
 
 [invalid_flags_1]
-size=9
-1\name="a skeleton"
-1\value=0x00002000
-2\name="a merchant"
-2\value=0x00000040
-3\name="outpost liaison, diplomat, or artifact requesting visitor"
-3\value=0x00000800
+size=8
+1\name="a merchant"
+1\value=0x00000040
+2\name="outpost liaison, diplomat, or artifact requesting visitor"
+2\value=0x00000800
+3\name="an invader or hostile"
+3\value=0x00020000
 4\name="an invader or hostile"
-4\value=0x00020000
-5\name="an invader or hostile"
-5\value=0x00080000
-6\name="resident, invader or ambusher"
-6\value=0x00600000
-7\name="part of a merchant caravan"
-7\value=0x00000080
-8\name="inactive, currently not in play"
-8\value=0x00000002
-9\name="marauder"
-9\value=0x00000010
+4\value=0x00080000
+5\name="resident, invader or ambusher"
+5\value=0x00600000
+6\name="part of a merchant caravan"
+6\value=0x00000080
+7\name="inactive, currently not in play"
+7\value=0x00000002
+8\name="marauder"
+8\value=0x00000010
 
 [invalid_flags_2]
 size=5

--- a/share/memory_layouts/windows/v0.50.13-itch_win64.ini
+++ b/share/memory_layouts/windows/v0.50.13-itch_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/share/memory_layouts/windows/v0.50.13-steam_win64.ini
+++ b/share/memory_layouts/windows/v0.50.13-steam_win64.ini
@@ -177,12 +177,6 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
-[item_filter_offsets]
-item_subtype=0x0002
-mat_class=0x0004
-mat_type=0x0006
-mat_index=0x0008
-
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -381,7 +375,11 @@ gloves_vector=0x00c8
 shoes_vector=0x00e0
 shield_vector=0x00f8
 weapon_vector=0x0110
-uniform_item_filter=0x0004
+uniform_spec_item_type=0x0004
+uniform_spec_item_subtype=0x0006
+uniform_spec_mat_class=0x0008
+uniform_spec_mat_type=0x000a
+uniform_spec_mat_index=0x000c
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 
@@ -412,25 +410,23 @@ setupdwarfgame_units=0x1ee8
 size=0
 
 [invalid_flags_1]
-size=9
-1\name="a skeleton"
-1\value=0x00002000
-2\name="a merchant"
-2\value=0x00000040
-3\name="outpost liaison, diplomat, or artifact requesting visitor"
-3\value=0x00000800
+size=8
+1\name="a merchant"
+1\value=0x00000040
+2\name="outpost liaison, diplomat, or artifact requesting visitor"
+2\value=0x00000800
+3\name="an invader or hostile"
+3\value=0x00020000
 4\name="an invader or hostile"
-4\value=0x00020000
-5\name="an invader or hostile"
-5\value=0x00080000
-6\name="resident, invader or ambusher"
-6\value=0x00600000
-7\name="part of a merchant caravan"
-7\value=0x00000080
-8\name="inactive, currently not in play"
-8\value=0x00000002
-9\name="marauder"
-9\value=0x00000010
+4\value=0x00080000
+5\name="resident, invader or ambusher"
+5\value=0x00600000
+6\name="part of a merchant caravan"
+6\value=0x00000080
+7\name="inactive, currently not in play"
+7\value=0x00000002
+8\name="marauder"
+8\value=0x00000010
 
 [invalid_flags_2]
 size=5

--- a/share/memory_layouts/windows/v0.50.13-steam_win64.ini
+++ b/share/memory_layouts/windows/v0.50.13-steam_win64.ini
@@ -177,6 +177,12 @@ adjective=0x00a8
 tool_flags=0x00a8
 tool_adjective=0x00d8
 
+[item_filter_offsets]
+item_subtype=0x0002
+mat_class=0x0004
+mat_type=0x0006
+mat_index=0x0008
+
 [weapon_subtype_offsets]
 single_size=0x00f8
 multi_size=0x00fc
@@ -380,6 +386,7 @@ uniform_spec_item_subtype=0x0006
 uniform_spec_mat_class=0x0008
 uniform_spec_mat_type=0x000a
 uniform_spec_mat_index=0x000c
+uniform_item_filter=0x0004
 uniform_indiv_choice=0x0030
 equipment_update=0x01b8
 

--- a/src/memorylayout.h
+++ b/src/memorylayout.h
@@ -32,7 +32,6 @@ public:
         MEM_HEALTH,
         MEM_WOUND,
         MEM_ITEM,
-        MEM_ITEM_FILTER,
         MEM_ARMOR_SUB,
         MEM_GEN_REF,
         MEM_SYN,
@@ -73,7 +72,6 @@ public:
         case MEM_HEALTH: return "health_offsets";
         case MEM_WOUND: return "unit_wound_offsets";
         case MEM_ITEM: return "item_offsets";
-        case MEM_ITEM_FILTER: return "item_filter_offsets";
         case MEM_ARMOR_SUB: return "armor_subtype_offsets";
         case MEM_GEN_REF: return "general_ref_offsets";
         case MEM_SYN: return "syndrome_offsets";
@@ -139,7 +137,6 @@ public:
     qint16 health_offset(const QString & key) const {return offset(MEM_HEALTH,key);}
     qint16 wound_offset(const QString & key) const {return offset(MEM_WOUND,key);}
     qint16 item_offset(const QString & key) const {return offset(MEM_ITEM,key);}
-    qint16 item_filter_offset(const QString & key) const {return offset(MEM_ITEM_FILTER,key);}
     qint16 armor_subtype_offset(const QString & key) const {return offset(MEM_ARMOR_SUB,key);}
     qint16 general_ref_offset(const QString & key) const {return offset(MEM_GEN_REF,key);}
     qint16 syndrome_offset(const QString & key) const {return offset(MEM_SYN,key);}
@@ -206,9 +203,6 @@ public:
     }
     VIRTADDR item_field(VIRTADDR object, const QString &key) const {
         return field_address(object, MEM_ITEM, key);
-    }
-    VIRTADDR item_filter_field(VIRTADDR object, const QString &key) const {
-        return field_address(object, MEM_ITEM_FILTER, key);
     }
     VIRTADDR armor_subtype_field(VIRTADDR object, const QString &key) const {
         return field_address(object, MEM_ARMOR_SUB, key);


### PR DESCRIPTION
item_filter is no longer a subcompound in DFHack. It makes it difficult to generate memory layout the old way.

fix https://github.com/DFHack/scripts/commit/d129d7260f1852c8123dce2a650579595393d96e#r143280613

will break auto-updater users when merged